### PR TITLE
Change 1130 hand's finger tip sensors to default PST

### DIFF
--- a/sr_hand_config/1130/general_info.yaml
+++ b/sr_hand_config/1130/general_info.yaml
@@ -17,7 +17,7 @@ type: 'hand_e'
 version: 'E4'
 fingers: [th, ff, mf, rf, lf]
 sensors:
-  tip: {th: mst, ff: mst, mf: mst, rf: mst, lf: mst}
+  tip: {th: pst, ff: pst, mf: pst, rf: pst, lf: pst}
   mid: {}
   prox: {}
   palm: {}


### PR DESCRIPTION
## Proposed changes

Change 1130 hand's finger tip sensors to default PST sensors.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [x] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
